### PR TITLE
readme updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ NOTE: this program is for the purposes of Helsinki Movement Lab and most of the 
 
 ## Installation
 
-The installation is easiest using conda. Clone this repository, change directory to the repository root and run `conda env create`. This should create a conda environment called `gaitbase` with the necessary dependencies. Activate the environment and run `gaitbase` to start the program. On Windows, you can create a desktop shortcut by running `gaitbase_make_shortcut` in the activated environment.
+The installation is easiest using conda. Clone this repository, change directory to the repository root and run `conda env create`. This should create a conda environment called `gaitbase` with the necessary dependencies. Activate the environment and run `gaitbase` to start the program. On Windows, you can create a desktop shortcut by running `gaitbase_make_shortcut` (or, if that fails, `python -c "from gaitbase.utils import make_my_shortcut; make_my_shortcut()"`) in the activated environment.
 
 If you want to install in development mode (so that the package is actually run from the local repository clone), install as above, then run `pip uninstall gaitbase`, followed by `pip install -e .` in the repository root.
 


### PR DESCRIPTION
Added instructions for creating desktop a shortcut when gaitbase_make_shortcut fails (e.g. on HUS computers).